### PR TITLE
Fixed geocodeBestResult() results

### DIFF
--- a/src/geocoder-fr.js
+++ b/src/geocoder-fr.js
@@ -40,7 +40,12 @@ class GeocoderFr {
             return null;
         }
 
-        return {long: data.features[0].properties.x, lat: data.features[0].properties.y};
+        return {
+            x: data.features[0].properties.x,
+            y: data.features[0].properties.y,
+            long: data.features[0].geometry.coordinates[0],
+            lat: data.features[0].geometry.coordinates[1]
+        };
     }
 
     /**


### PR DESCRIPTION
I corrected long & lat results with the longitude & latitude coordinates. 
I add x & y to the results to avoid retrocompatibility